### PR TITLE
Fixed version to match up with the tarball code at  https://pypi.python.org/pypi/lightify/

### DIFF
--- a/lightify/__init__.py
+++ b/lightify/__init__.py
@@ -23,11 +23,10 @@
 
 import binascii
 import socket
-import sys
 import struct
 import logging
 
-__version__ = '1.0.2'
+__version__ = '1.0.3'
 
 MODULE = __name__
 PORT = 4000


### PR DESCRIPTION
To keep the same version that the one available at https://pypi.python.org, we need to fix it on the master branch. 

https://pypi.python.org/packages/1d/fd/b70051fb6b727d6a8a8c6fc1cf9818a7d0b5ef953cde503cb8687b5d9ff6/lightify-1.0.3.tar.gz#md5=eceb7514ecd2fb338f0953022ee02d1f
