### PR TITLE
self.__seq variable out of range error

### DIFF
--- a/lightify/__init__.py
+++ b/lightify/__init__.py
@@ -233,7 +233,7 @@ class Lightify:
 
     def next_seq(self):
         self.__seq = self.__seq + 1
-        return self.__seq
+        return self.__seq % 256
 
     def build_global_command(self, command, data):
         length = 6 + len(data)

--- a/lightify/__init__.py
+++ b/lightify/__init__.py
@@ -44,8 +44,8 @@ MAX_TEMPERATURE = 8000
 MIN_TEMPERATURE = 2000
 MAX_LUMINANCE = 100
 MAX_RGB = 255
-    
- 
+
+
 """
 Commands
 ========
@@ -88,10 +88,10 @@ class Luminary(object):
 
     def set_rgb(self, r, g, b, time):
         data = self.__conn.build_colour(
-            self, 
-            min(MAX_RGB, r), 
-            min(MAX_RGB, g), 
-            min(MAX_RGB, b), 
+            self,
+            min(MAX_RGB, r),
+            min(MAX_RGB, g),
+            min(MAX_RGB, b),
             time
         )
         self.__conn.send(data)


### PR DESCRIPTION
I discovered this error using a nuimo controller to change brightness and controlling lightify light.
After a certain number of actions an error was raised concerning the self.__seq variable that was expected to be in the range 0-255.
Adding this correction the unexpected behaviour does not occur anymore.

I am referring to the "Fix out of bound issue" commit